### PR TITLE
support loading jmap.gz format

### DIFF
--- a/UEBlueprintGraphViewer/ParamMappings/JmapData.cs
+++ b/UEBlueprintGraphViewer/ParamMappings/JmapData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -25,7 +26,10 @@ public class JmapData
     
     public void Read(string path)
     {
-        using var reader = new FileStream(path, FileMode.Open, FileAccess.Read);
+        using var file = new FileStream(path, FileMode.Open, FileAccess.Read);
+        using Stream reader = path.EndsWith(".gz", StringComparison.OrdinalIgnoreCase)
+            ? new GZipStream(file, CompressionMode.Decompress)
+            : file;
         var result = JsonSerializer.Deserialize<JmapJson>(reader);
 
         foreach (var obj in result.Objects)

--- a/UEBlueprintGraphViewer/Views/Controls/GameProfileSettingsView.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/Controls/GameProfileSettingsView.axaml.cs
@@ -95,7 +95,7 @@ public partial class GameProfileSettingsView : UserControl
         var files = await storageProvider.OpenFilePickerAsync(new()
         {
             Title = "Select .jmap file",
-            FileTypeFilter = [new(".jmap file") { Patterns = ["*.jmap"] }]
+            FileTypeFilter = [new(".jmap file") { Patterns = ["*.jmap", "*.jmap.gz"] }]
         });
 
         if (files.Any())


### PR DESCRIPTION
jmap dumper supports writing jmap directly to compressed jmap.gz file, for games where dumps are massive (e.g. subnautica 2)

simply adds support for the compressed jmap to be selected and it is uncompressed when the jmap dump is loaded.