### PR TITLE
Small tweaks to set and get node visuals

### DIFF
--- a/UEBlueprintGraphViewer/Nodes/BPNode.cs
+++ b/UEBlueprintGraphViewer/Nodes/BPNode.cs
@@ -34,6 +34,9 @@ namespace UEBlueprintGraphViewer.Nodes
         public bool HeaderCenter;
         
         public bool CompactTitle;
+        
+        public GraphPin? TintPin;
+        public bool TintHeaderOnly;
 
         public bool ShowNameAsBody;
 

--- a/UEBlueprintGraphViewer/Nodes/BPNode.cs
+++ b/UEBlueprintGraphViewer/Nodes/BPNode.cs
@@ -32,6 +32,8 @@ namespace UEBlueprintGraphViewer.Nodes
 
         public bool HeaderHidden;
         public bool HeaderCenter;
+        
+        public bool CompactTitle;
 
         public bool ShowNameAsBody;
 
@@ -159,6 +161,7 @@ namespace UEBlueprintGraphViewer.Nodes
 
             NodeWidth = inputPadding + inputSize + bodySize + outputSize + outputPadding;
             NodeWidth = Math.Max(NodeWidth, Name.Length * charSize + 20);
+            if (CompactTitle) NodeWidth = Math.Max(NodeWidth, Name.Length * charSize + 80);
             NodeHeight += Math.Max(inputPinsHeight, outputPinsHeight);
         }
 

--- a/UEBlueprintGraphViewer/Nodes/K2Node_VariableGet.cs
+++ b/UEBlueprintGraphViewer/Nodes/K2Node_VariableGet.cs
@@ -18,6 +18,7 @@ namespace UEBlueprintGraphViewer.Nodes
             Pure = true;
             TargetPin = targetPin;
             VarPin = new GraphPin(variableName, EEdGraphPinDirection.EGPD_Output, data.PinType);
+            TintPin = VarPin;
             AddOutputPin(VarPin);
             if (TargetPin != null)
                 AddInputPin(TargetPin);

--- a/UEBlueprintGraphViewer/Nodes/K2Node_VariableSet.cs
+++ b/UEBlueprintGraphViewer/Nodes/K2Node_VariableSet.cs
@@ -18,6 +18,8 @@ namespace UEBlueprintGraphViewer.Nodes
             Property = data;
             HeaderHidden = true;
             CompactTitle = true;
+            TintPin = ValuePin;
+            TintHeaderOnly = true;
             this.ValuePin = ValuePin;
             this.ContextPin = ContextPin;
             MakePins(true, true);

--- a/UEBlueprintGraphViewer/Nodes/K2Node_VariableSet.cs
+++ b/UEBlueprintGraphViewer/Nodes/K2Node_VariableSet.cs
@@ -16,7 +16,8 @@ namespace UEBlueprintGraphViewer.Nodes
         public K2Node_VariableSet(PropertyData data, GraphPin ValuePin, GraphPin? ContextPin, KismetExpression Instr) : base("SET", Instr)
         {
             Property = data;
-            HeaderCenter = true;
+            HeaderHidden = true;
+            CompactTitle = true;
             this.ValuePin = ValuePin;
             this.ContextPin = ContextPin;
             MakePins(true, true);

--- a/UEBlueprintGraphViewer/Views/Controls/GraphView2.cs
+++ b/UEBlueprintGraphViewer/Views/Controls/GraphView2.cs
@@ -546,6 +546,9 @@ public class GraphView2 : ContentControl
             {
                 if (node.ShowNameAsBody)
                     canvas.DrawText2(node.Name, node.NodeWidth / 2f, node.NodeHeight / 2f + 10, SKTextAlign.Center, TextFontBody, TextPaint2);
+                
+                if (node.CompactTitle)
+                    canvas.DrawText2(node.Name, node.NodeWidth / 2f, 22, SKTextAlign.Center, TextFont, TextPaint);
 
                 canvas.DrawRoundRect(nodeRect, 5,5, NodeBorder);
 

--- a/UEBlueprintGraphViewer/Views/Controls/GraphView2.cs
+++ b/UEBlueprintGraphViewer/Views/Controls/GraphView2.cs
@@ -519,11 +519,36 @@ public class GraphView2 : ContentControl
                 ChangeStatus.Changed => NodeChangedBackg,
                 _ => NodeBackg,
             };
-            
+
             if (view.Scaling > 0.2)
                 canvas.DrawRoundRect(nodeRect, 5,5, backg);
             else
                 canvas.DrawRect(nodeRect, backg);
+            
+            if (node is { ChangeStatus: ChangeStatus.None, TintPin: not null } && view.Scaling > 0.2)
+            {
+                SKColor edge = ViewData.NodeBaseColor;
+                SKColor mid = ViewData.GetNodeTintColor(node.TintPin.PinType.PinCategory);
+                using SKPaint tintPaint = new()
+                {
+                    IsAntialias = true,
+                    Shader = SKShader.CreateLinearGradient(
+                        new SKPoint(0, 0), new SKPoint(node.NodeWidth, 0),
+                        [edge, mid, edge], [0f, 0.5f, 1f], SKShaderTileMode.Clamp),
+                };
+
+                if (node.TintHeaderOnly)
+                {
+                    SKRect headerRect = new(0, 0, node.NodeWidth, 34);
+                    using SKRoundRect rr = new(headerRect, 0);
+                    rr.SetNinePatch(headerRect, 5, 5, 5, 0);
+                    canvas.DrawRoundRect(rr, tintPaint);
+                }
+                else
+                {
+                    canvas.DrawRoundRect(nodeRect, 5, 5, tintPaint);
+                }
+            }
             
             if (!node.HeaderHidden)
             {

--- a/UEBlueprintGraphViewer/Views/ViewData.cs
+++ b/UEBlueprintGraphViewer/Views/ViewData.cs
@@ -82,6 +82,24 @@ namespace UEBlueprintGraphViewer.Views
 
         public static SKPaint SKUnknownColor = FromColor(SKColors.Red);
         
+        public static readonly SKColor NodeBaseColor = new(40, 40, 40);
+        private static readonly FrozenDictionary<PinType, SKColor> NodeTintColors =
+            SKPinsColors.Select(o => new KeyValuePair<PinType, SKColor>(
+                o.Key, BlendOver(o.Value.Color, NodeBaseColor, 0.18f))).ToFrozenDictionary();
+
+        public static SKColor GetNodeTintColor(PinType? type)
+        {
+            if (type != null && NodeTintColors.TryGetValue(type.Value, out SKColor color))
+                return color;
+            return SKUnknownColor.Color;
+        }
+
+        private static SKColor BlendOver(SKColor top, SKColor bottom, float alpha)
+        {
+            byte Mix(byte t, byte b) => (byte)(t * alpha + b * (1 - alpha));
+            return new SKColor(Mix(top.Red, bottom.Red), Mix(top.Green, bottom.Green), Mix(top.Blue, bottom.Blue));
+        }
+        
         public static SKPaint GetPinColorSK(PinType? type)
         {
             if (type != null && SKPinsColors.TryGetValue(type.Value, out SKPaint? color))


### PR DESCRIPTION
Firstly, thank you so so so much for making this awesome tool! I've been using it all day for modding and it's miles ahead of anything else out there for reading game code for understanding how the devs have implemented certain algorithms that I want to reuse or recreate in my mods! 

While working on this I felt like the set and get nodes should match how they look in the unreal engine editor. So this PR:
- Changes the set node from looking like a function to looking how it does in the editor
- Adds a gradient tint colour based on the output pin to a get or set node

Old:
<img width="1291" height="473" alt="image" src="https://github.com/user-attachments/assets/a984c81c-af38-4157-adbe-80803a22bd00" />

UE:
<img width="663" height="443" alt="image" src="https://github.com/user-attachments/assets/e45f2408-c6ba-48a2-b0cf-804e9dde21fe" />

New:
<img width="1127" height="299" alt="image" src="https://github.com/user-attachments/assets/f03e1988-c868-49ea-93c7-76a9ac71932f" />
