### PR TITLE
Minor quality of life tweaks

### DIFF
--- a/UEBlueprintGraphViewer/Settings.cs
+++ b/UEBlueprintGraphViewer/Settings.cs
@@ -102,6 +102,10 @@ namespace UEBlueprintGraphViewer
 
         [ObservableProperty]
         private EGame _UEVersion = EGame.GAME_UE5_5;
+        
+        public List<string> OpenTabs { get; set; } = [];
+        
+        public string? ActiveTab { get; set; }
 
         [JsonIgnore]
         public JmapData Jmap;

--- a/UEBlueprintGraphViewer/Settings.cs
+++ b/UEBlueprintGraphViewer/Settings.cs
@@ -35,6 +35,9 @@ namespace UEBlueprintGraphViewer
         [ObservableProperty]
         private bool isMSAGL;
 
+        [ObservableProperty]
+        private bool rememberOpenTabs = true;
+
         // Debug settings
         public static bool DrawDebugGraph;
 

--- a/UEBlueprintGraphViewer/Views/AssetInfoPanel.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/AssetInfoPanel.axaml.cs
@@ -50,6 +50,15 @@ namespace UEBlueprintGraphViewer.Views
             FunctionChoosen?.Invoke(this, lastSelected);
         }
         
+        public void SelectFunction(AssetFunctionViewModel func)
+        {
+            lastSelected = func;
+            if (EventList.ItemsSource?.Cast<AssetFunctionViewModel>().Contains(func) == true)
+                EventList.SelectedItem = func;
+            else
+                FunctionList.SelectedItem = func;
+        }
+        
         private void PropertySearchInCurrentGraph_OnClick(object? sender, RoutedEventArgs e)
         {
             if (PropertyList.SelectedItem is AssetPropertyViewModel prop)

--- a/UEBlueprintGraphViewer/Views/BPGraphViewer.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/BPGraphViewer.axaml.cs
@@ -79,6 +79,20 @@ namespace UEBlueprintGraphViewer.Views
             VM.Asset = asset;
         }
 
+        private bool _autoOpened;
+
+        protected override async void OnLoaded(RoutedEventArgs e)
+        {
+            base.OnLoaded(e);
+            
+            if (_autoOpened) return;
+            _autoOpened = true;
+
+            var target = VM.Asset.Events.FirstOrDefault() ?? VM.Asset.Functions.FirstOrDefault();
+            if (target != null)
+                await OpenFunction(target);
+        }
+
         public void DisableProgress()
         {
             VM.IsProgressVisible = false;

--- a/UEBlueprintGraphViewer/Views/BPGraphViewer.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/BPGraphViewer.axaml.cs
@@ -90,7 +90,10 @@ namespace UEBlueprintGraphViewer.Views
 
             var target = VM.Asset.Events.FirstOrDefault() ?? VM.Asset.Functions.FirstOrDefault();
             if (target != null)
+            {
+                AssetInfoPanel.SelectFunction(target);
                 await OpenFunction(target);
+            }
         }
 
         public void DisableProgress()

--- a/UEBlueprintGraphViewer/Views/MainWindow.axaml
+++ b/UEBlueprintGraphViewer/Views/MainWindow.axaml
@@ -117,6 +117,11 @@
 						<Setter Property="HeaderTemplate">
 							<DataTemplate x:DataType="x:String">
 								<StackPanel Orientation="Horizontal" Spacing="7" PointerPressed="Tab_OnPointerPressed">
+									<StackPanel.ContextMenu>
+										<ContextMenu>
+											<MenuItem Header="Close All Tabs" Click="CloseAllTabs_OnClick"/>
+										</ContextMenu>
+									</StackPanel.ContextMenu>
 									<TextBlock Text="{Binding .}"/>
 									<Button Content="x" Background="Transparent" Click="TabClose_OnClick" Padding="0"/>
 								</StackPanel>

--- a/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
@@ -106,6 +106,9 @@ namespace UEBlueprintGraphViewer
 
         private async Task RestoreOpenTabs(GameSettings game)
         {
+            if (!Settings.Instance.RememberOpenTabs)
+                return;
+
             foreach (var path in game.OpenTabs.ToList())
                 await LoadAsset(new AssetFile(path.SubstringAfterLast('/'), path));
 
@@ -136,7 +139,8 @@ namespace UEBlueprintGraphViewer
 
         private void PersistOpenTabs()
         {
-            if (!Design.IsDesignMode && !Settings.Instance.IsInCompareMode &&
+            if (!Design.IsDesignMode && Settings.Instance.RememberOpenTabs &&
+                !Settings.Instance.IsInCompareMode &&
                 Settings.Instance.Game is { ProfileName: not null } game)
             {
                 SaveOpenTabs(game);

--- a/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Avalonia.Platform;
 using Avalonia.Utilities;
+using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
 using CUE4Parse.Utils;
 using UEBlueprintGraphViewer.Assets;
@@ -362,6 +363,15 @@ namespace UEBlueprintGraphViewer
         private void CloseTab(Visual child)
         {
             AssetsTabs.Items.Remove(child.GetVisualAncestors().OfType<TabItem>().FirstOrDefault());
+        }
+
+        private void CloseAllTabs_OnClick(object? sender, RoutedEventArgs e)
+        {
+            var toClose = AssetsTabs.Items.OfType<TabItem>()
+                .Where(t => t.Classes.Contains("Closeable"))
+                .ToList();
+            foreach (var tab in toClose)
+                AssetsTabs.Items.Remove(tab);
         }
 
         public void AddTab(TabItem newTab)

--- a/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Avalonia.Platform;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
+using CUE4Parse.Utils;
 using UEBlueprintGraphViewer.Assets;
 using UEBlueprintGraphViewer.Comparing;
 using UEBlueprintGraphViewer.Nodes;
@@ -95,6 +96,44 @@ namespace UEBlueprintGraphViewer
                 Package = p;
                 viewModel.PopulateTree([.. Package.Assets.Select(o => o.Path)]);
                 viewModel.StatusText = "";
+
+                await RestoreOpenTabs(Settings.Instance.Game);
+            }
+        }
+
+        private async Task RestoreOpenTabs(GameSettings game)
+        {
+            foreach (var path in game.OpenTabs.ToList())
+                await LoadAsset(new AssetFile(path.SubstringAfterLast('/'), path));
+
+            if (game.ActiveTab != null &&
+                AssetsTabs.Items.FirstOrDefault(o => o is TabItem t && t.Tag?.ToString() == game.ActiveTab) is { } activeTab)
+                AssetsTabs.SelectedItem = activeTab;
+        }
+
+        private void SaveOpenTabs(GameSettings game)
+        {
+            var tabs = AssetsTabs.Items.OfType<TabItem>()
+                .Select(t => t.Tag?.ToString())
+                .Where(tag => tag is not null and not "MainTab")
+                .Select(tag => tag!)
+                .ToList();
+
+            game.OpenTabs = tabs;
+            game.ActiveTab = (AssetsTabs.SelectedItem as TabItem)?.Tag?.ToString() is { } active and not "MainTab"
+                ? active
+                : null;
+        }
+
+        protected override void OnClosing(WindowClosingEventArgs e)
+        {
+            base.OnClosing(e);
+            
+            if (!Design.IsDesignMode && !Settings.Instance.IsInCompareMode &&
+                Settings.Instance.Game is { ProfileName: not null } game)
+            {
+                SaveOpenTabs(game);
+                game.WriteConfig();
             }
         }
 

--- a/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
@@ -63,6 +63,8 @@ namespace UEBlueprintGraphViewer
                 OpenSettings();
                 return;
             }
+            
+            PersistOpenTabs();
 
             Package?.Dispose();
             PackageCompare1?.Dispose();
@@ -129,7 +131,11 @@ namespace UEBlueprintGraphViewer
         protected override void OnClosing(WindowClosingEventArgs e)
         {
             base.OnClosing(e);
-            
+            PersistOpenTabs();
+        }
+
+        private void PersistOpenTabs()
+        {
             if (!Design.IsDesignMode && !Settings.Instance.IsInCompareMode &&
                 Settings.Instance.Game is { ProfileName: not null } game)
             {

--- a/UEBlueprintGraphViewer/Views/SettingsWindow.axaml
+++ b/UEBlueprintGraphViewer/Views/SettingsWindow.axaml
@@ -33,6 +33,8 @@
 							  SelectionChanged="ProfileComboBox_SelectionChanged"
 							  MinWidth="130"/>
 					<Button Content="+" Width="24" Click="NewProfileButton_Click"/>
+					<Button Content="🗑" Width="24" Click="DeleteProfileButton_Click"
+							ToolTip.Tip="Delete the selected profile"/>
 				</StackPanel>
 			</Grid>
 			<local:GameProfileSettingsView DataContext="{Binding Game}" Updated="{Binding #root.CheckIsValid}"/>

--- a/UEBlueprintGraphViewer/Views/SettingsWindow.axaml
+++ b/UEBlueprintGraphViewer/Views/SettingsWindow.axaml
@@ -56,6 +56,11 @@
 				<TextBlock Grid.Row="0" ToolTip.Tip="MSAGL library will be used to layout nodes in graph. Might be mode chaotic or the opposite. Much longer to compute." Classes="Hint"/>
 
 				<CheckBox IsChecked="{Binding IsMSAGL}" Grid.Column="1" Grid.Row="0"/>
+
+				<TextBlock Grid.Row="1" Text="Remember open tabs" VerticalAlignment="Center"/>
+				<TextBlock Grid.Row="1" ToolTip.Tip="Reopen the tabs that were open last time when loading a profile." Classes="Hint"/>
+
+				<CheckBox IsChecked="{Binding RememberOpenTabs}" Grid.Column="1" Grid.Row="1"/>
 			</Grid>
         </StackPanel>
         <Button x:Name="ApplyButton" Grid.Row="1" HorizontalAlignment="Center" Content="Apply" Width="100" Click="ApplyButton_Click" />

--- a/UEBlueprintGraphViewer/Views/SettingsWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/SettingsWindow.axaml.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -66,6 +66,33 @@ namespace UEBlueprintGraphViewer
         private async void NewProfileButton_Click(object sender, RoutedEventArgs e)
         {
             await CreateNewProfile();
+        }
+
+        private async void DeleteProfileButton_Click(object sender, RoutedEventArgs e)
+        {
+            string profileName = settings.GameProfileName;
+            if (string.IsNullOrEmpty(profileName))
+                return;
+
+            var confirm = await DialogWindow.Show(
+                $"Delete profile \"{profileName}\"? This cannot be undone.",
+                "Delete profile", canCancel: true, windowOverride: this);
+            if (confirm.Result != DialogWindowResult.Ok)
+                return;
+
+            if (GameSettings.IsConfigExists(profileName))
+                File.Delete($"Profiles/{profileName}.json");
+
+            Profiles.Remove(profileName);
+
+            if (Profiles.Any())
+            {
+                settings.GameProfileName = Profiles[0];
+            }
+            else
+            {
+                await CreateNewProfile(false);
+            }
         }
 
         private void ProfileComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/UEBlueprintGraphViewer/Views/SettingsWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/SettingsWindow.axaml.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia.Controls;
+using Avalonia.Controls;
 using Avalonia.Interactivity;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -77,7 +77,8 @@ namespace UEBlueprintGraphViewer
             }
             else
             {
-                settings.Game.ProfileName = settings.GameProfileName;
+                game = new GameSettings { ProfileName = settings.GameProfileName };
+                settings.Game = game;
             }
             CheckIsValid();
         }


### PR DESCRIPTION
Some minor qol tweaks based on my usage of the tool today:
- save opened tabs to profile settings when you close the application, so when you reopen a profile, it reopens the tabs you had open previously
  - while working on this, I fixed a bug where on new profile creation it was populating the new profile using the settings of the old one. it did seem intentional as it "copies" everything from previous profile, but I don't agree with this design choice if it was so - and also meant that it was copying other settings like the new active tabs array, meaning that when you loaded the new profile, it was trying to open assets that only exist in the other game's profile
- when opening a tab, open the ubergraph automatically
  - if ubergraph is empty, try opening the first function
  - if there is no ubergraph or function, keep opening nothing as before
- add a right click option on tabs to close all tabs
- add a button to delete a profile