### PR TITLE
for each loop macros now contain array element pin and inline getters

### DIFF
--- a/UEBlueprintGraphViewer/BPGraph.cs
+++ b/UEBlueprintGraphViewer/BPGraph.cs
@@ -645,11 +645,19 @@ namespace UEBlueprintGraphViewer
         public void ProcessMacros()
         {
             Dictionary<int, int> outSeqMapping = [];
-            
+            HashSet<int> inlinedNodes = [];
+
             foreach (var macro in Settings.Instance.Macros)
             {
                 var patternNodes = macro.Value.Nodes;
                 if (patternNodes.Count > Nodes.Count) continue;
+
+                // collect pure array getters for array index of for each loops
+                inlinedNodes = patternNodes
+                    .Select((node, idx) => (node, idx))
+                    .Where(o => o.node.NodeType == nameof(K2Node_GetArrayItem))
+                    .Select(o => o.idx)
+                    .ToHashSet();
 
                 Stopwatch sw = Stopwatch.StartNew();
                 List<Edge2> edgesPattern = macro.Value.GetEdges();
@@ -670,10 +678,13 @@ namespace UEBlueprintGraphViewer
                     changed = false;
                     for (int i = 0; i < patternNodes.Count; i++)
                     {
+                        if (inlinedNodes.Contains(i)) continue;
+
                         var pNeighborIndices = patternNodes[i].Output
                             .SelectMany(p => p.LinkedTo)
                             .Where(p => p.ParentNode.NodeType != "K2Node_Tunnel")
                             .Select(p => patternNodes.IndexOf(p.ParentNode))
+                            .Where(idx => !inlinedNodes.Contains(idx))
                             .ToList();
 
                         var toRemove = new List<int>();
@@ -722,6 +733,7 @@ namespace UEBlueprintGraphViewer
                 
                 List<BPNode> toRemoveNodes = [];
                 List<BPNode> toAddNodes = [];
+                List<BPNode> toRemoveLeftoverNodes = [];
 
                 foreach (var result in results)
                 {
@@ -790,6 +802,9 @@ namespace UEBlueprintGraphViewer
                         }
                     }
 
+                    foreach (var inlinedIndex in inlinedNodes)
+                        CollectArrayItemNodes(patternNodes[inlinedIndex], patternNodes, result, links, toRemoveNodes, toRemoveLeftoverNodes);
+
                     var inputs = macro.Value.MacroInputNode!.Output
                         .Select(p => MakeMacroInstancePin(p, EngineEnums.EEdGraphPinDirection.EGPD_Input, links)).ToList();
                     var outputs = macro.Value.MacroOutputNode!.Input
@@ -800,6 +815,7 @@ namespace UEBlueprintGraphViewer
 
                 toRemoveNodes.ForEach(RemoveNode);
                 toAddNodes.ForEach(AddNode);
+                RemoveLeftoverNodes(toRemoveLeftoverNodes);
                 sw.Stop();
             }
 
@@ -834,13 +850,15 @@ namespace UEBlueprintGraphViewer
                 Dictionary<int, int> mappings = [];
                 mappingsOut = mappings;
                 HashSet<BPNode> failedNodes = [];
+                
+                int expectedCount = patternGraph.Nodes.Count - 2 - inlinedNodes.Count;
 
                 while (true)
                 {
                     mappings.Clear();
                     mappings[patternGraph.Nodes.IndexOf(firstNode)] = Nodes.IndexOf(node);
 
-                    if (!Test(firstNode, node) || mappings.Count != patternGraph.Nodes.Count - 2)
+                    if (!Test(firstNode, node) || mappings.Count != expectedCount)
                         return false;
 
                     if (CheckAllConnections(mappings, patternEdges, patternGraph.Nodes, seqNodePattern, out var failed))
@@ -859,7 +877,7 @@ namespace UEBlueprintGraphViewer
 
                     return TryMapPins(macroNode.Output, testNode.Output) ||
                            TryMapPins(macroNode.Input, testNode.Input) ||
-                           mappings.Count == patternGraph.Nodes.Count - 2;
+                           mappings.Count == expectedCount;
 
                     bool TryMapPins(List<GraphPin> mPins, List<GraphPin> tPins)
                     {
@@ -867,7 +885,8 @@ namespace UEBlueprintGraphViewer
                         {
                             foreach (var mLink in mPins[i].LinkedTo)
                             {
-                                if (mappings.ContainsKey(patternGraph.Nodes.IndexOf(mLink.ParentNode))) continue;
+                                int linkIndex = patternGraph.Nodes.IndexOf(mLink.ParentNode);
+                                if (inlinedNodes.Contains(linkIndex) || mappings.ContainsKey(linkIndex)) continue;
 
                                 if (tPins[i].LinkedTo.Any(tLink => Test(mLink.ParentNode, tLink.ParentNode)))
                                     return true;
@@ -883,6 +902,9 @@ namespace UEBlueprintGraphViewer
                 failedNode = null;
                 foreach (var edge in patternEdges)
                 {
+                    if (inlinedNodes.Contains(edge.FromNodeIndex) || inlinedNodes.Contains(edge.ToNodeIndex))
+                        continue;
+
                     if (patternNodes[edge.FromNodeIndex] == seqNodePattern)
                     {
                         if (!mapping.TryGetValue(edge.FromNodeIndex, out int fromIdSeq))
@@ -930,6 +952,120 @@ namespace UEBlueprintGraphViewer
                     }
                 }
                 return true;
+            }
+
+            // for for each loops, find all inlined copies of the macro array getter and make them a single macro instance pin
+            void CollectArrayItemNodes(BPNode getterPattern, List<BPNode> patternNodes, Dictionary<int, int> result,
+                Dictionary<GraphPin, List<GraphPin>> links, List<BPNode> toRemoveNodes, List<BPNode> leftoverNodes)
+            {
+                if (getterPattern.Input.Count < 2 || getterPattern.Output.Count < 1)
+                    return;
+
+                // pin of the output tunnel the collected getters are routed to
+                var elementTunnelPin = getterPattern.Output[0].LinkedTo
+                    .FirstOrDefault(o => o.ParentNode is { NodeType: "K2Node_Tunnel" });
+                if (elementTunnelPin == null || !links.TryGetValue(elementTunnelPin, out var elementLinks))
+                    return;
+
+                // index comes from the array index temporary variable of this macro instance
+                var patternIndexSource = getterPattern.Input[1].LinkedTo.FirstOrDefault();
+                if (patternIndexSource == null ||
+                    !result.TryGetValue(patternNodes.IndexOf(patternIndexSource.ParentNode), out int indexNodeIndex))
+                    return;
+                var indexPin = Nodes[indexNodeIndex].Output[patternIndexSource.ParentNode.Output.IndexOf(patternIndexSource)];
+
+                // array comes from the input tunnel, take the pin the loop itself uses to know which array it is
+                var arrayTunnelPin = getterPattern.Input[0].LinkedTo
+                    .FirstOrDefault(o => o.ParentNode is { NodeType: "K2Node_Tunnel" });
+                GraphPin? arrayPin = arrayTunnelPin != null && links.TryGetValue(arrayTunnelPin, out var arrayLinks)
+                    ? arrayLinks.FirstOrDefault()
+                    : null;
+
+                foreach (var node in Nodes.ToList())
+                {
+                    if (!IsArrayGetter(node, out var getterArray, out var getterIndex, out var getterValue)) continue;
+                    if (!getterIndex!.LinkedTo.Contains(indexPin)) continue;
+                    if (arrayPin != null && !IsSameArray(getterArray!, arrayPin)) continue;
+                    if (toRemoveNodes.Contains(node)) continue;
+
+                    elementLinks.Add(getterValue!);
+                    toRemoveNodes.Add(node);
+                    CollectSourceNodes(getterArray!, leftoverNodes);
+                }
+            }
+            
+            static bool IsArrayGetter(BPNode node, out GraphPin? arrayPin, out GraphPin? indexPin, out GraphPin? valuePin)
+            {
+                if (node is K2Node_GetArrayItem getter)
+                {
+                    arrayPin = getter.ArrayPin;
+                    indexPin = getter.IndexPin;
+                    valuePin = getter.VarPin;
+                    return true;
+                }
+
+                arrayPin = null;
+                indexPin = null;
+                valuePin = null;
+
+                if (node is not K2Node_CallArrayFunction || node.Name != "GET")
+                    return false;
+
+                arrayPin = node.Input.Find(o => o.PinName == "TargetArray");
+                indexPin = node.Input.Find(o => o.PinName == "Index");
+                valuePin = node.GetFirstOutputParam();
+
+                return arrayPin != null && indexPin != null && valuePin != null;
+            }
+            
+            static bool IsSameArray(GraphPin pin1, GraphPin pin2)
+            {
+                if (pin1 == pin2) return true;
+
+                if (pin1.Property != null && pin2.Property != null)
+                    return pin1.Property.Name == pin2.Property.Name && pin1.Property.Owner == pin2.Property.Owner;
+
+                var source1 = pin1.LinkedTo.FirstOrDefault();
+                var source2 = pin2.LinkedTo.FirstOrDefault();
+                if (source1 == null || source2 == null)
+                    return source1 == source2;
+
+                return source1 == source2 ||
+                       (source1.ParentNode.NodeType == source2.ParentNode.NodeType &&
+                        source1.ParentNode.Name == source2.ParentNode.Name &&
+                        source1.PinName == source2.PinName);
+            }
+            
+            static void CollectSourceNodes(GraphPin pin, List<BPNode> collected)
+            {
+                foreach (var source in pin.LinkedTo)
+                {
+                    if (source.ParentNode is not { Pure: true } sourceNode || collected.Contains(sourceNode))
+                        continue;
+
+                    collected.Add(sourceNode);
+                    foreach (var input in sourceNode.Input)
+                        CollectSourceNodes(input, collected);
+                }
+            }
+            
+            void RemoveLeftoverNodes(List<BPNode> nodes)
+            {
+                bool removed = true;
+                while (removed)
+                {
+                    removed = false;
+                    foreach (var node in nodes)
+                    {
+                        if (!Nodes.Contains(node)) continue;
+
+                        // still used by something else
+                        if (node.Output.Any(o => o.LinkedTo.Count > 0)) continue;
+                        
+                        RemoveNode(node);
+                        removed = true;
+                    }
+                }
             }
 
             void MapTunnelPins(List<GraphPin> macroPins, List<GraphPin> testPins, Dictionary<GraphPin, List<GraphPin>> links)

--- a/UEBlueprintGraphViewer/Macros/For Each Loop with Break.json
+++ b/UEBlueprintGraphViewer/Macros/For Each Loop with Break.json
@@ -528,7 +528,8 @@
           "LinkedTo": [
             "b1ee68f0-92b9-4c0b-b34b-7e68d57dcf9e",
             "5a43e032-9b55-499a-8c48-33d51dfacdfc",
-            "5680d3e0-9e93-453f-ac5e-4374c12d3a64"
+            "5680d3e0-9e93-453f-ac5e-4374c12d3a64",
+            "66be896b-995a-4b8d-8865-d776b1623abf"
           ]
         }
       ]
@@ -1066,6 +1067,73 @@
       ]
     },
     {
+      "Name": "GET",
+      "NodeType": "K2Node_GetArrayItem",
+      "LocationX": 2809,
+      "LocationY": 510,
+      "NodeWidth": 121,
+      "NodeHeight": 64,
+      "HeaderHidden": true,
+      "HeaderCenter": false,
+      "ShowNameAsBody": true,
+      "Pure": true,
+      "Input": [
+        {
+          "Guid": "b228d377-00ae-42f0-b590-7284145337b5",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 1
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "259a622f-8634-4f63-a4cd-d609378c185b"
+          ]
+        },
+        {
+          "Guid": "66be896b-995a-4b8d-8865-d776b1623abf",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 5,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "de6cf24a-93bc-4f04-be84-b510a6997f15"
+          ]
+        }
+      ],
+      "Output": [
+        {
+          "Guid": "8e0acd7d-66cd-4f1d-931a-8a6c5bd47ec6",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "df7ed139-3735-4704-865d-6c1430b1932a"
+          ]
+        }
+      ]
+    },
+    {
       "Name": "Inputs",
       "NodeType": "K2Node_Tunnel",
       "LocationX": -194,
@@ -1109,7 +1177,8 @@
           "IsNameHidden": false,
           "IsHidden": false,
           "LinkedTo": [
-            "8c26c71f-21c4-449d-87a2-42bbf057d7e6"
+            "8c26c71f-21c4-449d-87a2-42bbf057d7e6",
+            "b228d377-00ae-42f0-b590-7284145337b5"
           ]
         },
         {
@@ -1136,8 +1205,8 @@
       "NodeType": "K2Node_Tunnel",
       "LocationX": 3069,
       "LocationY": 0,
-      "NodeWidth": 102,
-      "NodeHeight": 136,
+      "NodeWidth": 150,
+      "NodeHeight": 168,
       "HeaderHidden": false,
       "HeaderCenter": false,
       "ShowNameAsBody": false,
@@ -1158,6 +1227,23 @@
           "IsHidden": false,
           "LinkedTo": [
             "6aa535d6-1e6c-4241-a579-56901f65186a"
+          ]
+        },
+        {
+          "Guid": "df7ed139-3735-4704-865d-6c1430b1932a",
+          "PinName": "Array Element",
+          "PinFriendlyName": "Array Element",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "8e0acd7d-66cd-4f1d-931a-8a6c5bd47ec6"
           ]
         },
         {

--- a/UEBlueprintGraphViewer/Macros/For Each Loop with Break2 (break is unused).json
+++ b/UEBlueprintGraphViewer/Macros/For Each Loop with Break2 (break is unused).json
@@ -527,7 +527,8 @@
           "LinkedTo": [
             "b1ee68f0-92b9-4c0b-b34b-7e68d57dcf9e",
             "5a43e032-9b55-499a-8c48-33d51dfacdfc",
-            "5680d3e0-9e93-453f-ac5e-4374c12d3a64"
+            "5680d3e0-9e93-453f-ac5e-4374c12d3a64",
+            "61c33076-f647-48d5-981d-b1d82d6d5d1c"
           ]
         }
       ]
@@ -985,6 +986,73 @@
       ]
     },
     {
+      "Name": "GET",
+      "NodeType": "K2Node_GetArrayItem",
+      "LocationX": 2809,
+      "LocationY": 510,
+      "NodeWidth": 121,
+      "NodeHeight": 64,
+      "HeaderHidden": true,
+      "HeaderCenter": false,
+      "ShowNameAsBody": true,
+      "Pure": true,
+      "Input": [
+        {
+          "Guid": "9fe2c445-4918-4d8d-9794-dbcff2852a09",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 1
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "259a622f-8634-4f63-a4cd-d609378c185b"
+          ]
+        },
+        {
+          "Guid": "61c33076-f647-48d5-981d-b1d82d6d5d1c",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 5,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "de6cf24a-93bc-4f04-be84-b510a6997f15"
+          ]
+        }
+      ],
+      "Output": [
+        {
+          "Guid": "94683ec2-5952-4841-8968-def869b8a7d0",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "b4b09afe-4a36-494c-b03e-80012b613bb0"
+          ]
+        }
+      ]
+    },
+    {
       "Name": "Inputs",
       "NodeType": "K2Node_Tunnel",
       "LocationX": -194,
@@ -1028,7 +1096,8 @@
           "IsNameHidden": false,
           "IsHidden": false,
           "LinkedTo": [
-            "8c26c71f-21c4-449d-87a2-42bbf057d7e6"
+            "8c26c71f-21c4-449d-87a2-42bbf057d7e6",
+            "9fe2c445-4918-4d8d-9794-dbcff2852a09"
           ]
         },
         {
@@ -1053,8 +1122,8 @@
       "NodeType": "K2Node_Tunnel",
       "LocationX": 3069,
       "LocationY": 0,
-      "NodeWidth": 102,
-      "NodeHeight": 136,
+      "NodeWidth": 150,
+      "NodeHeight": 168,
       "HeaderHidden": false,
       "HeaderCenter": false,
       "ShowNameAsBody": false,
@@ -1075,6 +1144,23 @@
           "IsHidden": false,
           "LinkedTo": [
             "6aa535d6-1e6c-4241-a579-56901f65186a"
+          ]
+        },
+        {
+          "Guid": "b4b09afe-4a36-494c-b03e-80012b613bb0",
+          "PinName": "Array Element",
+          "PinFriendlyName": "Array Element",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "94683ec2-5952-4841-8968-def869b8a7d0"
           ]
         },
         {

--- a/UEBlueprintGraphViewer/Macros/For Each Loop.json
+++ b/UEBlueprintGraphViewer/Macros/For Each Loop.json
@@ -30,7 +30,8 @@
           "LinkedTo": [
             "2f24621a-b0bf-43c0-8d44-595688866a5d",
             "c4d639d4-b4f4-4e1f-a163-5d62bacff049",
-            "0f0a43ed-0a0c-4bd9-9ffb-58985be9aab8"
+            "0f0a43ed-0a0c-4bd9-9ffb-58985be9aab8",
+            "fdca8302-21e4-48ba-909a-502ee8d1ac09"
           ]
         }
       ]
@@ -753,6 +754,73 @@
       ]
     },
     {
+      "Name": "GET",
+      "NodeType": "K2Node_GetArrayItem",
+      "LocationX": 2142,
+      "LocationY": 528,
+      "NodeWidth": 121,
+      "NodeHeight": 64,
+      "HeaderHidden": true,
+      "HeaderCenter": false,
+      "ShowNameAsBody": true,
+      "Pure": true,
+      "Input": [
+        {
+          "Guid": "c962afca-a44a-4675-97c6-dba2e94723a6",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 1
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "356dcfa3-fda7-4ad9-9541-8017e7726474"
+          ]
+        },
+        {
+          "Guid": "fdca8302-21e4-48ba-909a-502ee8d1ac09",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 5,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "356d1cdd-5bc0-41e1-8aa9-06cbba9b1024"
+          ]
+        }
+      ],
+      "Output": [
+        {
+          "Guid": "a829cde9-6688-4e56-80a5-c6f8287f7ebd",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "6def54da-5044-437f-9e84-80a141c79556"
+          ]
+        }
+      ]
+    },
+    {
       "Name": "Inputs",
       "NodeType": "K2Node_Tunnel",
       "LocationX": -180,
@@ -796,7 +864,8 @@
           "IsNameHidden": false,
           "IsHidden": false,
           "LinkedTo": [
-            "0ead3005-dccc-42d0-a453-408cc20da6f4"
+            "0ead3005-dccc-42d0-a453-408cc20da6f4",
+            "c962afca-a44a-4675-97c6-dba2e94723a6"
           ]
         }
       ]
@@ -806,8 +875,8 @@
       "NodeType": "K2Node_Tunnel",
       "LocationX": 2402,
       "LocationY": -8,
-      "NodeWidth": 135,
-      "NodeHeight": 135,
+      "NodeWidth": 150,
+      "NodeHeight": 167,
       "HeaderHidden": false,
       "HeaderCenter": false,
       "ShowNameAsBody": false,
@@ -828,6 +897,23 @@
           "IsHidden": false,
           "LinkedTo": [
             "0ffee355-c910-48f0-894a-0d9ab2e18ea8"
+          ]
+        },
+        {
+          "Guid": "6def54da-5044-437f-9e84-80a141c79556",
+          "PinName": "Array Element",
+          "PinFriendlyName": "Array Element",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "a829cde9-6688-4e56-80a5-c6f8287f7ebd"
           ]
         },
         {

--- a/UEBlueprintGraphViewer/Macros/Reverse for Each Loop.json
+++ b/UEBlueprintGraphViewer/Macros/Reverse for Each Loop.json
@@ -244,7 +244,8 @@
           "LinkedTo": [
             "3ae612d9-6033-48be-9d49-dc65757a88eb",
             "bc3615d7-2217-4733-b35b-02014a914b9e",
-            "07a3d083-6293-4a8e-9849-4a9bc92e0b2d"
+            "07a3d083-6293-4a8e-9849-4a9bc92e0b2d",
+            "ad0b8333-4166-42fa-8eba-db1d9c6c4295"
           ]
         }
       ]
@@ -1015,6 +1016,73 @@
       ]
     },
     {
+      "Name": "GET",
+      "NodeType": "K2Node_GetArrayItem",
+      "LocationX": 2678,
+      "LocationY": 912,
+      "NodeWidth": 121,
+      "NodeHeight": 64,
+      "HeaderHidden": true,
+      "HeaderCenter": false,
+      "ShowNameAsBody": true,
+      "Pure": true,
+      "Input": [
+        {
+          "Guid": "b9779cee-dcef-4616-b484-9ff372db8316",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 1
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "6c511b7c-ee9f-47e0-aa90-85457d3be754"
+          ]
+        },
+        {
+          "Guid": "ad0b8333-4166-42fa-8eba-db1d9c6c4295",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 5,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "18409ab1-933b-4e3f-94bf-5eef5c5a598a"
+          ]
+        }
+      ],
+      "Output": [
+        {
+          "Guid": "a43a46cd-b0e2-413e-a189-d48e96218b54",
+          "PinName": "",
+          "PinFriendlyName": "",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "880b615f-c731-4eb6-96c1-f65010708c69"
+          ]
+        }
+      ]
+    },
+    {
       "Name": "Inputs",
       "NodeType": "K2Node_Tunnel",
       "LocationX": -208,
@@ -1059,7 +1127,8 @@
           "IsHidden": false,
           "LinkedTo": [
             "7a9fbe5e-a228-4682-835a-d009d939adbd",
-			"7b94498d-3791-4d86-b371-c506373a417c"
+            "7b94498d-3791-4d86-b371-c506373a417c",
+            "b9779cee-dcef-4616-b484-9ff372db8316"
           ]
         }
       ]
@@ -1069,14 +1138,14 @@
       "NodeType": "K2Node_Tunnel",
       "LocationX": 2938,
       "LocationY": 0,
-      "NodeWidth": 112,
-      "NodeHeight": 136,
+      "NodeWidth": 150,
+      "NodeHeight": 168,
       "HeaderHidden": false,
       "HeaderCenter": false,
       "ShowNameAsBody": false,
       "Pure": true,
       "Input": [
-	    {
+        {
           "Guid": "e51fc30f-31f6-455c-b1f6-df69ba968732",
           "PinName": "Loop Body",
           "PinFriendlyName": "Loop Body",
@@ -1091,6 +1160,23 @@
           "IsHidden": false,
           "LinkedTo": [
             "97b2719c-b53c-45ee-a4bb-2d8b66923d6c"
+          ]
+        },
+        {
+          "Guid": "880b615f-c731-4eb6-96c1-f65010708c69",
+          "PinName": "Array Element",
+          "PinFriendlyName": "Array Element",
+          "PinType": {
+            "PinSubCategoryObject": "None",
+            "PinCategory": 22,
+            "PinSubCategory": 0,
+            "ContainerType": 0
+          },
+          "Value": "",
+          "IsNameHidden": false,
+          "IsHidden": false,
+          "LinkedTo": [
+            "a43a46cd-b0e2-413e-a189-d48e96218b54"
           ]
         },
         {


### PR DESCRIPTION
Currently, for each loop macros are not returning array element pin. This PR adds the array element pin and converts the inline getters (that use array index on a get of the input array to loop) plus any duplicate connected nodes, into using the element instead. 

old:
<img width="1866" height="645" alt="oldforeach" src="https://github.com/user-attachments/assets/392bd52f-2f56-4660-9417-706ae45cc3f6" />

new:
<img width="1649" height="490" alt="newforeach" src="https://github.com/user-attachments/assets/9c31c5c3-6abb-4b6e-80de-54b1cd88dd81" />

original code:
<img width="1451" height="272" alt="image" src="https://github.com/user-attachments/assets/dbf40277-66e3-4479-99a9-7080b7af8af5" />

I also tested a case where the loop macro was incomplete because a node in it was missing, and in this case the result is the same (the top image the get is in a different position because I had moved it manually)

<img width="1506" height="1660" alt="foreachtest1" src="https://github.com/user-attachments/assets/7a2041e0-e8d2-4e0f-af3c-fd7c4a4aec4f" />
