### PR TITLE
fix bug where changing game settings and clicking apply wasnt applying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# jetbrains workspace
+.idea/

--- a/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
+++ b/UEBlueprintGraphViewer/Views/MainWindow.axaml.cs
@@ -144,7 +144,18 @@ namespace UEBlueprintGraphViewer
                 Settings.Instance.Game is { ProfileName: not null } game)
             {
                 SaveOpenTabs(game);
-                game.WriteConfig();
+                
+                if (GameSettings.IsConfigExists(game.ProfileName))
+                {
+                    var onDisk = GameSettings.ReadConfig(game.ProfileName);
+                    onDisk.OpenTabs = game.OpenTabs;
+                    onDisk.ActiveTab = game.ActiveTab;
+                    onDisk.WriteConfig();
+                }
+                else
+                {
+                    game.WriteConfig();
+                }
             }
         }
 


### PR DESCRIPTION
Fixes bug introduced in #7 @ [this line](https://github.com/glgen/UEBlueprintGraphViewer/commit/5e04c162c5da4db02097f7fdb28628ae6fd2a351#diff-e85a3ba36143a2d0e8e4fa1d2ebfb70ded214f798ee6a45ca8ce99a34c3a9752R136) where after clicking apply, in the persist open tabs function, it was writing back to config using the settings from before they were changed.

Also ignore rider/jetbrains workspace folder as I'm getting annoyed with all the workspace xml files it keeps generating